### PR TITLE
Fix #81, use other version for local builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 
 script:
   - VERSION=$(git rev-parse --short HEAD)
-  - sed -i -e 's|XXXVERSIONXXX|'$VERSION'|' $PWD/ESP8266WirelessPrintAsync/ESP8266WirelessPrintAsync.ino
+  - sed -i -e 's|#define SKETCH_VERSION ".*"|#define SKETCH_VERSION "'$VERSION'"|' $PWD/ESP8266WirelessPrintAsync/ESP8266WirelessPrintAsync.ino
   - arduino-1.8.8/arduino --pref build.path=. --verify --verbose-build --board $BD $PWD/ESP8266WirelessPrintAsync/ESP8266WirelessPrintAsync.ino
   - BOARD=$(echo $BD | cut -d ":" -f 3)
   - mv ./ESP8266WirelessPrintAsync.ino.bin "ESP8266WirelessPrintAsync_${BOARD}_${VERSION}.bin"

--- a/ESP8266WirelessPrintAsync/ESP8266WirelessPrintAsync.ino
+++ b/ESP8266WirelessPrintAsync/ESP8266WirelessPrintAsync.ino
@@ -22,7 +22,7 @@ AsyncWebServer server(80);
 DNSServer dns;
 
 // Configurable parameters
-#define SKETCH_VERSION "XXXVERSIONXXX"  // Gets inserted at build time by .travis.yml
+#define SKETCH_VERSION "2.x-localbuild"  // Gets inserted at build time by .travis.yml
 #define USE_FAST_SD                     // Use Default fast SD clock, comment if your SD is an old or slow one.
 #define OTA_UPDATES                     // Enable OTA firmware updates, comment if you don't want it (OTA may lead to security issues because someone may load any code on device)
 //#define OTA_PASSWORD ""               // Uncomment to protect OTA updates and assign a password (inside "")

--- a/ESP8266WirelessPrintAsync/ESP8266WirelessPrintAsync.ino
+++ b/ESP8266WirelessPrintAsync/ESP8266WirelessPrintAsync.ino
@@ -22,7 +22,7 @@ AsyncWebServer server(80);
 DNSServer dns;
 
 // Configurable parameters
-#define SKETCH_VERSION "2.x-localbuild"  // Gets inserted at build time by .travis.yml
+#define SKETCH_VERSION "2.x-localbuild" // Gets inserted at build time by .travis.yml
 #define USE_FAST_SD                     // Use Default fast SD clock, comment if your SD is an old or slow one.
 #define OTA_UPDATES                     // Enable OTA firmware updates, comment if you don't want it (OTA may lead to security issues because someone may load any code on device)
 //#define OTA_PASSWORD ""               // Uncomment to protect OTA updates and assign a password (inside "")


### PR DESCRIPTION
Use `2.x-localbuild`  as the placeholder for the git commit when doing local builds, fixes #81