### PR TITLE
Use platformio's extend feature

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ lib_deps = ${common.lib_deps}
 [base:esp32]
 ; corresponds to https://github.com/platformio/platform-espressif32/releases/tag/v1.8.0
 ; see https://github.com/espressif/arduino-esp32/releases/tag/1.0.2
-platform = espressif32@1.0.2
+platform = espressif32@1.8.0
 framework = ${common.framework}
 lib_deps =
     ${common.lib_deps}

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,8 +10,17 @@
 
 [platformio]
 src_dir = ESP8266WirelessPrintAsync
+# we have to list the non-base environments explicitly
+# otherwise, platformio attempts to build the base ones, but they are incomplete and builds would fail
+default_envs =
+    nodemcuv2
+    d1_mini
+    esp32dev
 
+
+# common variables shared by the environments
 [common]
+framework = arduino
 lib_deps =
     https://github.com/greiman/SdFat#3b79f38
     https://github.com/me-no-dev/ESPAsyncWebServer#95dedf7
@@ -22,24 +31,37 @@ lib_deps =
     https://github.com/bblanchon/ArduinoJson#3df4efd
     https://github.com/Makuna/NeoPixelBus#9619fef
 
-[env:nodemcuv2]
-platform = espressif8266@2.0.0 ; Corresponds to https://github.com/platformio/platform-espressif8266/releases/tag/v2.0.0 = https://github.com/esp8266/Arduino/releases/tag/2.5.0
-board = nodemcuv2
-framework = arduino
-lib_deps =
-    ${common.lib_deps}
 
-[env:d1_mini]
-platform = espressif8266@2.0.0 ; Corresponds to https://github.com/platformio/platform-espressif8266/releases/tag/v2.0.0 = https://github.com/esp8266/Arduino/releases/tag/2.5.0
-board = d1_mini
-framework = arduino
-lib_deps =
-    ${common.lib_deps}
+# base environments
+# can be extended by board-specific environments
+[env:esp8266_base]
+; corresponds to https://github.com/platformio/platform-espressif8266/releases/tag/v2.0.0
+; see https://github.com/esp8266/Arduino/releases/tag/2.5.0
+platform = espressif8266@2.0.0
+framework = ${common.framework}
+lib_deps = ${common.lib_deps}
 
-[env:esp32dev]
-platform = espressif32@1.8.0 ; Corresponds to https://github.com/platformio/platform-espressif32/releases/tag/v1.8.0 = https://github.com/espressif/arduino-esp32/releases/tag/1.0.2
-board = esp32dev
-framework = arduino
+[env:esp32_base]
+; corresponds to https://github.com/platformio/platform-espressif32/releases/tag/v1.8.0
+; see https://github.com/espressif/arduino-esp32/releases/tag/1.0.2
+platform = espressif32
+framework = ${common.framework}
 lib_deps =
     ${common.lib_deps}
     https://github.com/bbx10/Hash_tng
+
+
+[env:nodemcuv2]
+board = nodemcuv2
+extends = env:esp8266_base
+
+[env:d1_mini]
+board = d1_mini
+extends = env:esp8266_base
+
+# esp32dev works for the majority of ESP32 based dev boards
+# there are more specific board configurations available, feel free to send PRs adding new ones
+[env:esp32dev]
+board = esp32dev
+extends = env:esp32_base
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -44,7 +44,7 @@ lib_deps = ${common.lib_deps}
 [env:esp32_base]
 ; corresponds to https://github.com/platformio/platform-espressif32/releases/tag/v1.8.0
 ; see https://github.com/espressif/arduino-esp32/releases/tag/1.0.2
-platform = espressif32
+platform = espressif32@1.0.2
 framework = ${common.framework}
 lib_deps =
     ${common.lib_deps}

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,12 +10,6 @@
 
 [platformio]
 src_dir = ESP8266WirelessPrintAsync
-# we have to list the non-base environments explicitly
-# otherwise, platformio attempts to build the base ones, but they are incomplete and builds would fail
-default_envs =
-    nodemcuv2
-    d1_mini
-    esp32dev
 
 
 # common variables shared by the environments
@@ -34,14 +28,14 @@ lib_deps =
 
 # base environments
 # can be extended by board-specific environments
-[env:esp8266_base]
+[base:esp8266]
 ; corresponds to https://github.com/platformio/platform-espressif8266/releases/tag/v2.0.0
 ; see https://github.com/esp8266/Arduino/releases/tag/2.5.0
 platform = espressif8266@2.0.0
 framework = ${common.framework}
 lib_deps = ${common.lib_deps}
 
-[env:esp32_base]
+[base:esp32]
 ; corresponds to https://github.com/platformio/platform-espressif32/releases/tag/v1.8.0
 ; see https://github.com/espressif/arduino-esp32/releases/tag/1.0.2
 platform = espressif32@1.0.2
@@ -53,15 +47,15 @@ lib_deps =
 
 [env:nodemcuv2]
 board = nodemcuv2
-extends = env:esp8266_base
+extends = base:esp8266
 
 [env:d1_mini]
 board = d1_mini
-extends = env:esp8266_base
+extends = base:esp8266
 
 # esp32dev works for the majority of ESP32 based dev boards
 # there are more specific board configurations available, feel free to send PRs adding new ones
 [env:esp32dev]
 board = esp32dev
-extends = env:esp32_base
+extends = base:esp32
 


### PR DESCRIPTION
While working on Marlin, I found a new (well, new to me) feature in PlatformIO. Using `extends` saves duplicate code and helps maintain similar environments (e.g., the ones using the same platform, framework etc.). I've modified the PlatformIO configuration to use those. I also took the moment and improved the comments. (I *hate* any form of inline comments and lines which exceed my screen size...)